### PR TITLE
Add 24kHz playback support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The aim of the module is to facilitate creating real-time conversational apps. T
 
 - Request audio recording permissions
 - Get clean (applying Acoustic Echo Cancelling) microphone samples in PCM format (1 channel 16 bit at 16kHz)
-- Play audio samples in PCM format (1 channel 16 bit at 16kHz). Playback happens through main speaker unless external audio sources are connected.
+- Play audio samples in PCM format (1 channel 16 bit). Supports playback at **16kHz** or **24kHz**. Playback happens through main speaker unless external audio sources are connected.
 - Provide volume level both for the input and output samples. Float between 0 and 1.
 - [iOS only] Get microphone mode and prompt user to select a microphone mode.
 
@@ -57,8 +57,10 @@ Please check out our [examples/](./examples) to get full sample code.
     const audioChunk = "SOME PCM DATA BASE64 ENCODED HERE"
     const buffer = Buffer.from(audioChunk, "base64");
     const pcmData = new Uint8Array(buffer);
-    playPCMData(pcmData);
-   ```
+    // Optional second argument sets the sample rate (16000 or 24000).
+    // Defaults to 16000 if omitted.
+    playPCMData(pcmData, 16000);
+  ```
 
 1. Get microphone samples
 

--- a/android/src/main/java/expo/modules/twowayaudio/ExpoTwoWayAudioModule.kt
+++ b/android/src/main/java/expo/modules/twowayaudio/ExpoTwoWayAudioModule.kt
@@ -58,8 +58,8 @@ class ExpoTwoWayAudioModule : Module() {
              ))
          }
 
-         Function("playPCMData") { data: kotlin.ByteArray ->
-             audioEngine?.playPCMData(data)
+         Function("playPCMData") { data: kotlin.ByteArray, sampleRate: Int? ->
+             audioEngine?.playPCMData(data, sampleRate ?: 16000)
          }
 
          Function("bypassVoiceProcessing") { bypass: Boolean ->

--- a/ios/AudioEngine.swift
+++ b/ios/AudioEngine.swift
@@ -182,7 +182,7 @@ class AudioEngine {
         }
     }
     
-    func playPCMData(_ pcmData: Data) {
+    func playPCMData(_ pcmData: Data, sampleRate: Int) {
         // Looks like we don't get a proper AEC for the very first chunks of audio that we play.
         // To work around this, we will discard microphone input for the first few milliseconds.
         // This will give the AEC time to adapt to the playback audio.
@@ -196,7 +196,7 @@ class AudioEngine {
             }
         }
         
-        guard let buffer = createBuffer(from: pcmData) else {
+        guard let buffer = createBuffer(from: pcmData, sampleRate: sampleRate) else {
             print("Failed to create audio buffer")
             return
         }
@@ -208,11 +208,11 @@ class AudioEngine {
     }
 
     
-    private func createBuffer(from data: Data) -> AVAudioPCMBuffer? {
+    private func createBuffer(from data: Data, sampleRate: Int) -> AVAudioPCMBuffer? {
         let frameCount = UInt32(data.count) / 2 // 16-bit input = 2 bytes per frame
         
         let format = AVAudioFormat(commonFormat: .pcmFormatFloat32,
-                                   sampleRate: 16000,
+                                   sampleRate: Double(sampleRate),
                                    channels: 1,
                                    interleaved: false)!
         

--- a/ios/ExpoTwoWayAudioModule.swift
+++ b/ios/ExpoTwoWayAudioModule.swift
@@ -106,8 +106,8 @@ public class ExpoTwoWayAudioModule: Module {
 
         }
 
-        Function("playPCMData") { (pcmData: Data) in
-            self.audioEngine?.playPCMData(pcmData)
+        Function("playPCMData") { (pcmData: Data, sampleRate: Int?) in
+            self.audioEngine?.playPCMData(pcmData, sampleRate: sampleRate ?? 16000)
         }
 
         Function("bypassVoiceProcessing") { (bypass: Bool) in

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,12 +1,14 @@
 import { type PermissionResponse, createPermissionHook } from "expo-modules-core";
 import ExpoTwoWayAudioModule from "./ExpoTwoWayAudioModule";
 
+export type SampleRate = 16000 | 24000;
+
 export async function initialize() {
   return await ExpoTwoWayAudioModule.initialize();
 }
 
-export function playPCMData(audioData: Uint8Array) {
-  return ExpoTwoWayAudioModule.playPCMData(audioData);
+export function playPCMData(audioData: Uint8Array, sampleRate: SampleRate = 16000) {
+  return ExpoTwoWayAudioModule.playPCMData(audioData, sampleRate);
 }
 
 export function bypassVoiceProcessing(bypass: boolean) {


### PR DESCRIPTION
## Summary
- allow selecting sample rate when playing PCM data
- handle optional sample rate on Android and iOS
- manage playback `AudioTrack` sample rate on Android
- document new argument in README usage example
- document playback sample rate support in README

## Testing
- `npx biome check --write src ios android README.md`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_6854b8e98e9c832a9429ed957abd9c57